### PR TITLE
fix: Add tsconfig.jest.json to fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,11 @@
   "homepage": "https://github.com/techswitch-learners/testswitch-frontend-candidate#readme",
   "jest": {
     "preset": "ts-jest",
+    "globals": {
+      "ts-jest": {
+        "tsConfig": "tsconfig.jest.json"
+      }
+    },
     "moduleFileExtensions": [
       "ts",
       "tsx",
@@ -42,12 +47,12 @@
     }
   },
   "dependencies": {
-    "@zeit/next-sass": "^1.0.1",
     "next": "^9.3.4",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },
   "devDependencies": {
+    "@zeit/next-sass": "^1.0.1",
     "@testing-library/jest-dom": "^5.5.0",
     "@testing-library/react": "^10.0.2",
     "@types/jest": "^25.2.1",

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react"
+    "jsx": "preserve"
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
We found that running next start would modify our tsconfig.json so that jest couldn't parse react.

I've fixed this by adding a jest-specific extension to tsconfig.json - not an ideal fix, but it seems by far the easiest and worth it for a project this short.