### PR TITLE
Test library api

### DIFF
--- a/api/candidateApiClient.module.ts
+++ b/api/candidateApiClient.module.ts
@@ -1,4 +1,7 @@
-﻿import fetch from "node-fetch";
+﻿import getConfig from "next/config";
+import fetch from "node-fetch";
+
+﻿
 
 export interface SessionCandidate {
     firstName: string;
@@ -12,10 +15,11 @@ export interface CandidateTestStatus {
 }
 
 export async function getSessionCandidate(token: string): Promise<SessionCandidate> {
-    const baseUrl = `https://testswitch-api-staging.herokuapp.com/sessions/`;
+    const {publicRuntimeConfig} = getConfig();
+    const baseUrl = publicRuntimeConfig.API_URL;
     try {
         const result = await fetch(
-            `${baseUrl}${token}`
+            `${baseUrl}/sessions/${token}`
         );
         const data = await result.json();
         return data;

--- a/api/candidateApiClient.module.ts
+++ b/api/candidateApiClient.module.ts
@@ -1,8 +1,6 @@
 ﻿import getConfig from "next/config";
 import fetch from "node-fetch";
 
-﻿
-
 export interface SessionCandidate {
     firstName: string;
     lastName: string;

--- a/components/TestLibraryStepper/TestLibraryStepper.tsx
+++ b/components/TestLibraryStepper/TestLibraryStepper.tsx
@@ -15,14 +15,12 @@ interface TestLibraryStepperProps {
     candidateTestStatuses: CandidateTestStatus[];
 }
 
-function getSteps(testArr: CandidateTestStatus[]) {
+function getSteps(testArr: CandidateTestStatus[]): string[] {
     //set labels for steps
-    const testLabelArray = [];
-    testLabelArray.push(testArr.map(test => test.testName));
-    return testLabelArray;
+    return testArr.map(test => test.testName);
 }
 
-function getActiveStep(testArr: CandidateTestStatus[]) {
+function getActiveStep(testArr: CandidateTestStatus[]): number {
     //check for number of completed tests
     const completedTests = (testArr.filter(({testStatus}) => testStatus === "Completed"));
     return completedTests.length;
@@ -39,8 +37,8 @@ export default function TestLibraryStepper(props: TestLibraryStepperProps): JSX.
                 <Stepper style={{backgroundColor: "transparent"}} alternativeLabel activeStep={activeStep}
                          connector
                              ={<TestSwitchConnector/>}>
-                    {steps.map((label, status) => (
-                        <Step key={label.length}>
+                    {steps.map((label, index) => (
+                        <Step key={index}>
                             <StepLabel StepIconComponent={TestSwitchStepIcon} className="stepLabel"><h1
                                 style={h1Style}>{label}</h1>
                             </StepLabel>

--- a/components/TestLibraryStepper/TestLibraryStepper.tsx
+++ b/components/TestLibraryStepper/TestLibraryStepper.tsx
@@ -1,33 +1,31 @@
 ﻿import React from "react";
 import {Step, StepLabel, Stepper, Typography} from '@material-ui/core';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {CandidateTestStatus} from "../../pages/api/candidateApiClient.module";
 import TestSwitchStepIcon from "../TestLibraryStepperIcons/TestLibraryStepperIcons";
 import {h1Style, TestSwitchConnector, TestSwitchTheme} from "../TestLibraryOverrides/TestLibraryOverrides"
 import Link from "next/link";
 import scss from '../TestLibraryStepper/TestLibraryStepper.module.scss';
 
-
-interface TestLibraryStepperProps {
-    candidateTestStatus: CandidateTestStatus[];
+interface CandidateTestStatus {
+    testName: string;
+    testResult: string;
 }
 
-function getSteps() {
-    //TODO: mock data, set number of steps based on test range, maybe props.candidateTestStatus.tests.length?
-    const testNumber = 3;
+interface TestLibraryStepperProps {
+    candidateTestStatuses: CandidateTestStatus[];
+}
 
+function getSteps(testArr: CandidateTestStatus[]) {
     //set labels for steps
     const testLabelArray = [];
-    while (testLabelArray.length + 1 <= testNumber) {
-        testLabelArray.push(`Test ${testLabelArray.length + 1}`);
-    }
+    testLabelArray.push(testArr.map(test=>test.testName));
     return testLabelArray;
 }
 
 export default function TestLibraryStepper(props: TestLibraryStepperProps): JSX.Element {
-    const steps = getSteps();
-    //TODO this is example data, set active step with candidate number of results, maybe props.candidateTestStatus.results.length?
-    const activeStep = 1;
+    const steps = getSteps(props.candidateTestStatuses);
+    let activeStep = 0;
+    const completedTests = props.candidateTestStatuses.map(test => test.testResult === 'Completed'?(test.testName):('none'));
 
     return (
         <article className="stepperContainer">
@@ -35,7 +33,7 @@ export default function TestLibraryStepper(props: TestLibraryStepperProps): JSX.
                 <Stepper style={{backgroundColor: "transparent"}} alternativeLabel activeStep={activeStep}
                          connector={<TestSwitchConnector/>}>
                     {steps.map((label, status) => (
-                        <Step key={label}>
+                        <Step key={label.length}>
                             <StepLabel StepIconComponent={TestSwitchStepIcon} className="stepLabel"><h1
                                 style={h1Style}>{label}</h1>
                             </StepLabel>

--- a/components/TestLibraryStepper/TestLibraryStepper.tsx
+++ b/components/TestLibraryStepper/TestLibraryStepper.tsx
@@ -8,7 +8,7 @@ import scss from '../TestLibraryStepper/TestLibraryStepper.module.scss';
 
 interface CandidateTestStatus {
     testName: string;
-    testResult: string;
+    testStatus: string;
 }
 
 interface TestLibraryStepperProps {
@@ -22,16 +22,23 @@ function getSteps(testArr: CandidateTestStatus[]) {
     return testLabelArray;
 }
 
+function getActiveStep(testArr:CandidateTestStatus[]) {
+    //check for number of completed tests
+    const completedTests=(testArr.filter(({testStatus})=>testStatus==="Completed"));
+    return completedTests.length;
+}
+
+
 export default function TestLibraryStepper(props: TestLibraryStepperProps): JSX.Element {
     const steps = getSteps(props.candidateTestStatuses);
-    let activeStep = 0;
-    const completedTests = props.candidateTestStatuses.map(test => test.testResult === 'Completed'?(test.testName):('none'));
+    const activeStep = getActiveStep(props.candidateTestStatuses);
 
     return (
         <article className="stepperContainer">
             <MuiThemeProvider theme={TestSwitchTheme}>
                 <Stepper style={{backgroundColor: "transparent"}} alternativeLabel activeStep={activeStep}
-                         connector={<TestSwitchConnector/>}>
+                         connector
+                             ={<TestSwitchConnector/>}>
                     {steps.map((label, status) => (
                         <Step key={label.length}>
                             <StepLabel StepIconComponent={TestSwitchStepIcon} className="stepLabel"><h1
@@ -43,7 +50,7 @@ export default function TestLibraryStepper(props: TestLibraryStepperProps): JSX.
             </MuiThemeProvider>
             <section className="stepperBtnContainer">
                 {activeStep === steps.length ? (
-                    <Typography align={"center"} className="finished">
+                    <Typography style={h1Style} align={"center"} className="finished">
                         All tests completed.
                     </Typography>
                 ) : (

--- a/components/TestLibraryStepper/TestLibraryStepper.tsx
+++ b/components/TestLibraryStepper/TestLibraryStepper.tsx
@@ -18,13 +18,13 @@ interface TestLibraryStepperProps {
 function getSteps(testArr: CandidateTestStatus[]) {
     //set labels for steps
     const testLabelArray = [];
-    testLabelArray.push(testArr.map(test=>test.testName));
+    testLabelArray.push(testArr.map(test => test.testName));
     return testLabelArray;
 }
 
-function getActiveStep(testArr:CandidateTestStatus[]) {
+function getActiveStep(testArr: CandidateTestStatus[]) {
     //check for number of completed tests
-    const completedTests=(testArr.filter(({testStatus})=>testStatus==="Completed"));
+    const completedTests = (testArr.filter(({testStatus}) => testStatus === "Completed"));
     return completedTests.length;
 }
 

--- a/pages/api/candidateApiClient.module.ts
+++ b/pages/api/candidateApiClient.module.ts
@@ -6,9 +6,9 @@ export interface SessionCandidate {
     testStatuses: CandidateTestStatus[];
 }
 
-interface CandidateTestStatus {
+export interface CandidateTestStatus {
     testName: string;
-    testResult: string;
+    testStatus: string;
 }
 
 export async function getSessionCandidate(token: string):Promise<SessionCandidate> {
@@ -24,19 +24,3 @@ export async function getSessionCandidate(token: string):Promise<SessionCandidat
         return error.message;
     }
 }
-
-export async function getCandidateTests(token: string): Promise<SessionCandidate>{
-    const baseUrl = `https://testswitch-api-staging.herokuapp.com/sessions/`;
-    try {
-        const result = await fetch(
-            //TODO: placeholder endpoint
-            `${baseUrl}+${token}`
-        );
-        const data = await result.json();
-        return data.testStatuses
-    } catch (error) {
-        console.error(error);
-        return error.message;
-    }
-}
-

--- a/pages/api/candidateApiClient.module.ts
+++ b/pages/api/candidateApiClient.module.ts
@@ -1,38 +1,42 @@
 ﻿import fetch from "node-fetch";
 
-export interface CandidateTestStatus {
-    testId: string;
+export interface SessionCandidate {
+    firstName: string;
+    lastName: string;
+    testStatuses: CandidateTestStatus[];
+}
+
+interface CandidateTestStatus {
+    testName: string;
     testResult: string;
 }
 
-const baseUrl = `https://localhost:5001`;
-
-export async function getCandidateTestResults() {
+export async function getSessionCandidate(token: string):Promise<SessionCandidate> {
+    const baseUrl = `https://testswitch-api-staging.herokuapp.com/sessions/`;
     try {
         const result = await fetch(
-            //TODO: placeholder endpoint
-            `https://testswitch-api-staging.herokuapp.com/candidates`
+            `${baseUrl}${token}`
         );
         const data = await result.json();
-        //TODO: configure for future api call to candidate results, this is currently set to the candidates endpoint
-        return data.items;
+        return data;
     } catch (error) {
         console.error(error);
         return error.message;
     }
 }
 
-export async function getCandidateTests() {
+export async function getCandidateTests(token: string): Promise<SessionCandidate>{
+    const baseUrl = `https://testswitch-api-staging.herokuapp.com/sessions/`;
     try {
         const result = await fetch(
             //TODO: placeholder endpoint
-            `https://testswitch-api-staging.herokuapp.com/candidates`
+            `${baseUrl}+${token}`
         );
         const data = await result.json();
-        //TODO: configure for future api call to candidate results, this is currently set to the candidates endpoint
-        return data.items[0].id;
+        return data.testStatuses
     } catch (error) {
         console.error(error);
         return error.message;
     }
 }
+

--- a/pages/api/candidateApiClient.module.ts
+++ b/pages/api/candidateApiClient.module.ts
@@ -11,7 +11,7 @@ export interface CandidateTestStatus {
     testStatus: string;
 }
 
-export async function getSessionCandidate(token: string):Promise<SessionCandidate> {
+export async function getSessionCandidate(token: string): Promise<SessionCandidate> {
     const baseUrl = `https://testswitch-api-staging.herokuapp.com/sessions/`;
     try {
         const result = await fetch(

--- a/pages/testlibrary.tsx
+++ b/pages/testlibrary.tsx
@@ -2,14 +2,14 @@
 import {GetServerSideProps, NextPage} from "next";
 import Head from "next/head";
 import TestLibraryStepper from "../components/TestLibraryStepper/TestLibraryStepper";
-import {CandidateTestStatus, getCandidateTestResults, getCandidateTests} from "./api/candidateApiClient.module"
+import {SessionCandidate, getSessionCandidate} from "./api/candidateApiClient.module"
 import Layout from "../components/Layout/layout";
 
 interface TestlibraryProps {
-    candidateTestStatus: CandidateTestStatus[];
+    sessionCandidate : SessionCandidate;
 }
 
-const TestLibrary: NextPage<TestlibraryProps> = ({candidateTestStatus}) => {
+const TestLibrary: NextPage<TestlibraryProps> = ({sessionCandidate}) => {
     const [key, setKey] = React.useState(0);
 
     React.useEffect(() => {
@@ -20,24 +20,21 @@ const TestLibrary: NextPage<TestlibraryProps> = ({candidateTestStatus}) => {
             <Head>
                 <title>TestSwitch Test Library</title>
             </Head>
-            <TestLibraryStepper key={key} candidateTestStatus={candidateTestStatus}/>
+            <TestLibraryStepper key={key} candidateTestStatuses={sessionCandidate.testStatuses}/>
         </Layout>
     );
 };
 
-//TODO placeholder id for candidateID, need to know how candidate id is paired with session
-const candidateId = () => {
-    return 1;
-};
+//TODO placeholder id for candidateID,until url has token as query
+const candidateToken = `e701b7bc-6fb2-4b7e-a8ab-ef5ff66c43bd`;
 
 export const getServerSideProps: GetServerSideProps = async context => {
-    const tests = getCandidateTests();
-    const results = getCandidateTestResults();
+    const token = context.query.token as string;
+    const sessionData = getSessionCandidate(candidateToken);
 
     return {
         props: {
-            tests: await tests,
-            results: await results,
+            sessionCandidate: await sessionData
         }
     }
 };

--- a/pages/testlibrary.tsx
+++ b/pages/testlibrary.tsx
@@ -2,7 +2,7 @@
 import {GetServerSideProps, NextPage} from "next";
 import Head from "next/head";
 import TestLibraryStepper from "../components/TestLibraryStepper/TestLibraryStepper";
-import {getSessionCandidate, SessionCandidate} from "./api/candidateApiClient.module"
+import {getSessionCandidate, SessionCandidate} from "../api/candidateApiClient.module"
 import Layout from "../components/Layout/layout";
 import {assertTokenIsValid} from "../helpers/tokenHelpers";
 
@@ -26,13 +26,10 @@ const TestLibrary: NextPage<TestlibraryProps> = ({sessionCandidate}) => {
     );
 };
 
-//TODO placeholder id for candidateID,until url has token as query
-const candidateToken = `815b47a8-0b7a-4d6a-99e9-2fe130c5b774`;
-
 export const getServerSideProps: GetServerSideProps = async ({query, res}) => {
     await assertTokenIsValid(query, res);
-    const token = context.query.token as string;
-    const sessionData = getSessionCandidate(candidateToken);
+    const token = query.token as string;
+    const sessionData = getSessionCandidate(token);
 
     return {
         props: {

--- a/pages/testlibrary.tsx
+++ b/pages/testlibrary.tsx
@@ -26,7 +26,7 @@ const TestLibrary: NextPage<TestlibraryProps> = ({sessionCandidate}) => {
 };
 
 //TODO placeholder id for candidateID,until url has token as query
-const candidateToken = `e701b7bc-6fb2-4b7e-a8ab-ef5ff66c43bd`;
+const candidateToken = `815b47a8-0b7a-4d6a-99e9-2fe130c5b774`;
 
 export const getServerSideProps: GetServerSideProps = async context => {
     const token = context.query.token as string;

--- a/pages/testlibrary.tsx
+++ b/pages/testlibrary.tsx
@@ -2,11 +2,11 @@
 import {GetServerSideProps, NextPage} from "next";
 import Head from "next/head";
 import TestLibraryStepper from "../components/TestLibraryStepper/TestLibraryStepper";
-import {SessionCandidate, getSessionCandidate} from "./api/candidateApiClient.module"
+import {getSessionCandidate, SessionCandidate} from "./api/candidateApiClient.module"
 import Layout from "../components/Layout/layout";
 
 interface TestlibraryProps {
-    sessionCandidate : SessionCandidate;
+    sessionCandidate: SessionCandidate;
 }
 
 const TestLibrary: NextPage<TestlibraryProps> = ({sessionCandidate}) => {


### PR DESCRIPTION
have connected the sessions/{token} api up to the test library page. Currently have a default token set in the test library page to show some data. Expecting token to be accessible as context.query.token once the token url is set up.