### PR TITLE
Prevent access without valid token

### DIFF
--- a/api/sessionClient.ts
+++ b/api/sessionClient.ts
@@ -1,0 +1,10 @@
+﻿import getConfig from 'next/config';
+import fetch from "node-fetch";
+
+export async function checkToken(token: string): Promise<boolean> {
+    const {publicRuntimeConfig} = getConfig();
+    const baseUrl = publicRuntimeConfig.API_URL;
+    
+    const response = await fetch(`${baseUrl}/sessions/${token}`);
+    return response.ok;
+}

--- a/helpers/tokenHelpers.ts
+++ b/helpers/tokenHelpers.ts
@@ -1,0 +1,13 @@
+﻿import {ServerResponse} from "http";
+import {ParsedUrlQuery} from "querystring";
+import {checkToken} from "../api/sessionClient";
+
+export async function assertTokenIsValid(query: ParsedUrlQuery, response: ServerResponse): Promise<void> {
+    const token = query.token as string;
+    const tokenIsValid = await checkToken(token);
+    
+    if (!tokenIsValid) {
+        response.statusCode = 404;
+        response.end();
+    }
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 ﻿const withSass = require('@zeit/next-sass');
 module.exports = withSass({
-    cssModules: true
+    cssModules: true,
+    publicRuntimeConfig: {
+        API_URL: process.env.API_URL
+    }
 });
 
 WebFontConfig = {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,10 +1,11 @@
 import React from "react";
-import {NextPage} from 'next';
+import {GetServerSideProps, NextPage} from 'next';
 import scss from '../pageStyles/index.module.scss';
 import Layout from "../components/Layout/layout";
 import Link from "next/link";
 import {CandidateTestModel} from "../Models/CandidateTestModel";
 import {TestList} from "../components/CandidateTestView/Tests/TestList";
+import {assertTokenIsValid} from "../helpers/tokenHelpers";
 
 export const testToRender: CandidateTestModel = TestList[1];
 const Home: NextPage = () =>
@@ -23,6 +24,12 @@ const Home: NextPage = () =>
             </Link>
         </section>
     </Layout>;
+
+export const getServerSideProps: GetServerSideProps = async ({res, query}) => {
+    await assertTokenIsValid(query, res);
+    return { props: {}};
+};
+
 export default Home;
 
 

--- a/pages/submitted.tsx
+++ b/pages/submitted.tsx
@@ -1,7 +1,8 @@
-﻿import {NextPage} from 'next';
+﻿import {GetServerSideProps, NextPage} from 'next';
 import Layout from "../components/Layout/layout";
 import scss from "../pageStyles/submitted.module.scss";
 import React from "react";
+import {assertTokenIsValid} from "../helpers/tokenHelpers";
 
 const Submitted: NextPage = () => (
     <Layout>
@@ -12,4 +13,10 @@ const Submitted: NextPage = () => (
         </section>
     </Layout>
 );
+
+export const getServerSideProps: GetServerSideProps = async ({res, query}) => {
+    await assertTokenIsValid(query, res);
+    return { props: {}};
+};
+
 export default Submitted;

--- a/pages/testlibrary.tsx
+++ b/pages/testlibrary.tsx
@@ -4,6 +4,7 @@ import Head from "next/head";
 import TestLibraryStepper from "../components/TestLibraryStepper/TestLibraryStepper";
 import {CandidateTestStatus, getCandidateTestResults, getCandidateTests} from "./api/candidateApiClient.module"
 import Layout from "../components/Layout/layout";
+import {assertTokenIsValid} from "../helpers/tokenHelpers";
 
 interface TestlibraryProps {
     candidateTestStatus: CandidateTestStatus[];
@@ -30,7 +31,8 @@ const candidateId = () => {
     return 1;
 };
 
-export const getServerSideProps: GetServerSideProps = async context => {
+export const getServerSideProps: GetServerSideProps = async ({query, res}) => {
+    await assertTokenIsValid(query, res);
     const tests = getCandidateTests();
     const results = getCandidateTestResults();
 
@@ -41,6 +43,5 @@ export const getServerSideProps: GetServerSideProps = async context => {
         }
     }
 };
-
 
 export default TestLibrary;

--- a/pages/testpage.tsx
+++ b/pages/testpage.tsx
@@ -1,9 +1,10 @@
-﻿import {NextPage} from 'next';
+﻿import {GetServerSideProps, NextPage} from 'next';
 import React from "react";
 import Layout from "../components/Layout/layout";
 import CandidateTestView from "../components/CandidateTestView/CandidateTestView";
 import {CandidateTestModel} from "../Models/CandidateTestModel";
 import {testToRender} from "./index";
+import {assertTokenIsValid} from "../helpers/tokenHelpers";
 
 const TestPage: NextPage<CandidateTestModel> = () => {
     return (
@@ -11,6 +12,11 @@ const TestPage: NextPage<CandidateTestModel> = () => {
             <CandidateTestView test={testToRender}/>
         </Layout>
     )
+};
+
+export const getServerSideProps: GetServerSideProps = async ({res, query}) => {
+    await assertTokenIsValid(query, res);
+    return { props: {}};
 };
 
 export default TestPage;


### PR DESCRIPTION
The 4 main pages of the site can now only be accessed if you provide a valid token. For now, a 404 response is returned if your token is invalid.